### PR TITLE
Fix removed @*INC

### DIFF
--- a/t/client.t
+++ b/t/client.t
@@ -1,4 +1,4 @@
-BEGIN { @*INC.unshift('lib') }
+use lib 'lib';
 
 use Test;
 use JSON::Tiny;

--- a/t/server.t
+++ b/t/server.t
@@ -1,4 +1,4 @@
-BEGIN { @*INC.unshift( 'lib' ) }
+use lib 'lib';
 
 use Test;
 use JSON::Tiny;


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.