### PR TITLE
Add missing use statement

### DIFF
--- a/t/client.t
+++ b/t/client.t
@@ -3,6 +3,7 @@ use lib 'lib';
 use Test;
 use JSON::Tiny;
 use JSON::RPC::Client;
+use URI;
 
 plan( 39 );
 


### PR DESCRIPTION
Module loading is supposed to be lexical. We should therefore not depend on
our dependencies to load modules we need.